### PR TITLE
Fix client zip creation

### DIFF
--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -5,8 +5,8 @@ description = "Slack Addon"
 authors = ["OpenPype Team <info@openpype.io>"]
 license = "MIT License"
 homepage = "https://openpype.io"
-documentation = "https://openpype.io/docs/artist_getting_started"
-repository = "https://github.com/pypeclub/openpype"
+documentation = "https://github.com/ynput/ayon-slack/blob/develop/README.md"
+repository = "https://github.com/ynput/ayon-slack/tree/develop"
 readme = "README.md"
 
 [tool.poetry.dependencies]
@@ -16,10 +16,3 @@ slack-sdk = "^3.6.0"
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
-
-[openpype]
-
-exclude = [
-    "**/node_modules",
-    "**/__pycache__"
-]

--- a/create_package.py
+++ b/create_package.py
@@ -184,7 +184,8 @@ def zip_client_side(addon_package_dir, current_dir, log):
     """
 
     client_dir = os.path.join(current_dir, "client")
-    if not os.path.isdir(client_dir):
+    client_addon_dir = os.path.join(client_dir, ADDON_CLIENT_DIR)
+    if not os.path.isdir(client_addon_dir):
         log.info("Client directory was not found. Skipping")
         return
 
@@ -200,11 +201,14 @@ def zip_client_side(addon_package_dir, current_dir, log):
     zip_filepath = os.path.join(os.path.join(private_dir, "client.zip"))
     with ZipFileLongPaths(zip_filepath, "w", zipfile.ZIP_DEFLATED) as zipf:
         # Add client code content to zip
-        for path, sub_path in find_files_in_subdir(client_dir):
-            zipf.write(path, sub_path)
+        for path, sub_path in find_files_in_subdir(client_addon_dir):
+            zipf.write(path, os.path.join(ADDON_CLIENT_DIR, sub_path))
 
         # Add 'version.py' to client code
         zipf.write(src_version_path, dst_version_path)
+
+    src_pyproject = os.path.join(client_dir, "pyproject.toml")
+    shutil.copy(src_pyproject, private_dir)
 
 
 def create_server_package(


### PR DESCRIPTION
## Description
Changed how client file is created. Moved pyproject.toml into client codebase which is also next to `client.zip` file when package is created.