### PR TITLE
Handle missing settings when addon is disabled

### DIFF
--- a/client/ayon_slack/slack_module.py
+++ b/client/ayon_slack/slack_module.py
@@ -14,7 +14,12 @@ class SlackIntegrationModule(OpenPypeModule, IPluginPaths, ILaunchHookPaths):
     name = "slack"
 
     def initialize(self, modules_settings):
-        slack_settings = modules_settings[self.name]
+        try:
+            slack_settings = modules_settings[self.name]
+        except KeyError:
+            # settings cannot be loaded, addon is disabled?
+            self.enabled = False
+            return
         self.enabled = slack_settings["enabled"]
 
     def get_launch_hook_paths(self):

--- a/client/ayon_slack/slack_module.py
+++ b/client/ayon_slack/slack_module.py
@@ -14,13 +14,7 @@ class SlackIntegrationModule(OpenPypeModule, IPluginPaths, ILaunchHookPaths):
     name = "slack"
 
     def initialize(self, modules_settings):
-        try:
-            slack_settings = modules_settings[self.name]
-        except KeyError:
-            # settings cannot be loaded, addon is disabled?
-            self.enabled = False
-            return
-        self.enabled = slack_settings["enabled"]
+        self.enabled = True
 
     def get_launch_hook_paths(self):
         """Implementation of `ILaunchHookPaths`."""


### PR DESCRIPTION
## Issue
When Slack addon is disabled on AYON, console is still spammed with:

```traceback
WARNING:ModulesManager:Initialization of module SlackIntegrationModule failed.
Traceback (most recent call last):
  File "C:\Users\annat\AppData\Local\Ynput\AYON\addons\openpype_3.16.5-nightly.3\openpype\modules\base.py", line 800, in initialize_modules
    module = modules_item(self, modules_settings)
  File "C:\Users\annat\AppData\Local\Ynput\AYON\addons\openpype_3.16.5-nightly.3\openpype\modules\base.py", line 589, in __init__
    self.initialize(settings)
  File "C:\Users\annat\AppData\Local\Ynput\AYON\addons\openpype_3.16.5-nightly.3\openpype\modules\slack\slack_module.py", line 13, in initialize
    slack_settings = modules_settings[self.name]
KeyError: 'slack'
```

This is fixing it by silently disabling the addon in current session if settings for it are not available.