### PR TITLE
Use own settings

### DIFF
--- a/client/ayon_slack/plugins/publish/collect_slack_family.py
+++ b/client/ayon_slack/plugins/publish/collect_slack_family.py
@@ -53,7 +53,7 @@ class CollectSlackFamilies(pyblish.api.InstancePlugin,
             profile_keys = set(self.profiles[0].keys())
             key_values = {
                 key: value
-                for key, value in key_values.keys()
+                for key, value in key_values.items()
                 if key in profile_keys
             }
         profile = filter_profiles(self.profiles, key_values,

--- a/client/ayon_slack/plugins/publish/collect_slack_family.py
+++ b/client/ayon_slack/plugins/publish/collect_slack_family.py
@@ -18,7 +18,7 @@ class CollectSlackFamilies(pyblish.api.InstancePlugin,
     label = 'Collect Slack family'
     settings_category = "slack"
 
-    profiles = None
+    profiles = []
 
     @classmethod
     def get_attribute_defs(cls):
@@ -36,12 +36,26 @@ class CollectSlackFamilies(pyblish.api.InstancePlugin,
         task_data = instance.data["anatomyData"].get("task", {})
         family = self.main_family_from_instance(instance)
         key_values = {
-            "families": family,
-            "tasks": task_data.get("name"),
+            "product_types": family,
+            "task_names": task_data.get("name"),
             "task_types": task_data.get("type"),
             "hosts": instance.context.data["hostName"],
-            "subsets": instance.data["subset"]
+            "product_names": instance.data["subset"],
+
+            # Backwards compatibility
+            "families": family,
+            "tasks": task_data.get("name"),
+            "subsets": instance.data["subset"],
+            "subset_names": instance.data["subset"],
         }
+        # Filter 'key_values' for backwards compatibility
+        if self.profiles:
+            profile_keys = set(self.profiles[0].keys())
+            key_values = {
+                key: value
+                for key, value in key_values.keys()
+                if key in profile_keys
+            }
         profile = filter_profiles(self.profiles, key_values,
                                   logger=self.log)
 

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -11,7 +11,7 @@ class ChannelMessage(BaseSettingsModel):
 
 
 class Profile(BaseSettingsModel):
-    families: list[str] = Field(default_factory=list, title="Families")
+    product_types: list[str] = Field(default_factory=list, title="Product types")
     hosts: list[str] = Field(default_factory=list, title="Hosts")
     task_types: list[str] = Field(
         default_factory=list,
@@ -19,7 +19,7 @@ class Profile(BaseSettingsModel):
         enum_resolver=task_types_enum
     )
     task_names: list[str] = Field(default_factory=list, title="Task names")
-    subset_names: list[str] = Field(default_factory=list, title="Subset names")
+    product_names: list[str] = Field(default_factory=list, title="Product names")
     review_upload_limit: float = Field(
         50.0,
         title="Upload review maximum file size (MB)")


### PR DESCRIPTION
## Description
Use own addon settings that are not converted by openpype or ayon-core.

### Additional information
Changed settings to use `product_names` and `product_types` naming over `families`  Plugin `CollectSlackFamilies` is prepared to use own settings, but also can use backwards compatible settings.