### PR TITLE
Fix ChannelMessage.message text area

### DIFF
--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -7,7 +7,10 @@ class ChannelMessage(BaseSettingsModel):
     channels: list[str] = Field(default_factory=list, title="Channels")
     upload_thumbnail: bool = Field(default=True, title="Upload thumbnail")
     upload_review: bool = Field(default=True, title="Upload review")
-    message: str = Field('', title="Message")
+    message: str = Field('',
+        title="Message", 
+        widget="textarea"
+    )
 
 
 class Profile(BaseSettingsModel):
@@ -31,8 +34,7 @@ class Profile(BaseSettingsModel):
         default_factory=list,
         title="Messages to channels",
         description=_desc,
-        section="Messages",
-        widget="textarea"
+        section="Messages"
     )
 
 


### PR DESCRIPTION
## Changelog Description
Fix ChannelMessage.message text area

![messages_to_channels](https://github.com/user-attachments/assets/8ea32329-b714-4bbe-ae89-b2bd27acf132)

## Additional Info
This bug was found when I was preparing a screenshot for https://github.com/ynput/ayon-documentation/pull/218

## Testing notes:
Sending messages should work as usual.