### PR TITLE
Fix: sending notifications for farm destined instances

### DIFF
--- a/client/ayon_slack/plugins/publish/integrate_slack_api.py
+++ b/client/ayon_slack/plugins/publish/integrate_slack_api.py
@@ -31,6 +31,11 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
     optional = True
 
     def process(self, instance):
+        if instance.data.get("farm"):
+            self.log.debug(
+                "Instance is marked to be processed on farm. Skipping")
+            return
+
         thumbnail_path = self._get_thumbnail_path(instance)
         review_path = self._get_review_path(instance)
 


### PR DESCRIPTION
## Changelog Description
Slack notification is sent even during local publishing on instances meant for farm publishing. This results in duplicate messages and possibly wrong review files.

## Testing notes:
1. publish something via farm - check that it sent notification after farm publish
2. publish something locally
