### PR TITLE
Added usage of Anatomy template placeholders in channel name

### DIFF
--- a/client/ayon_slack/plugins/publish/integrate_slack_api.py
+++ b/client/ayon_slack/plugins/publish/integrate_slack_api.py
@@ -98,8 +98,8 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
             publish_files.add(review_path)
         return message, publish_files
 
-    def _get_filled_content(self, message_templ, instance, review_path=None):
-        """Use message_templ and data from instance to get message content.
+    def _get_filled_content(self, message, instance, review_path=None):
+        """Use message and data from instance to get dynamic message content.
 
         Reviews might be large, so allow only adding link to message instead of
         uploading only.
@@ -112,8 +112,8 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
         if review_path:
             fill_data["review_filepath"] = review_path
 
-        message_templ = (
-            message_templ
+        message = (
+            message
             .replace("{task}", "{task[name]}")
             .replace("{Task}", "{Task[name]}")
             .replace("{TASK}", "{TASK[NAME]}")
@@ -130,15 +130,14 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
 
         multiple_case_variants = prepare_template_data(fill_data)
         fill_data.update(multiple_case_variants)
-        message = ""
         try:
             message = self._escape_missing_keys(
-                message_templ, fill_data
+                message, fill_data
             ).format(**fill_data)
         except Exception:
             # shouldn't happen
             self.log.warning(
-                "Some keys are missing in {}".format(message_templ),
+                "Some keys are missing in {}".format(message),
                 exc_info=True)
 
         return message


### PR DESCRIPTION
## Changelog Description
This PR allows to dynamically fill from Anatomy values even in `channel name`, eg. Settings could be done once in `Studio settings` and any new project could send Slack notification to project name based channel without need to manually change `Project Settings`.

Also in `additional_message` set by artist in Publishser, previously only possible in text configured in Settings.

## Additional review information
Example would be have `{project[name]}_publishes`  in channel name, each project would send notification to different channel.

! It is still required for Slack admin to invite Slack bot to these channels. 

## Testing notes:
1. use Anatomy template placeholders in `channel` in `ayon+settings://slack/publish/CollectSlackFamilies/profiles/0/channel_messages/0/channels/0`
![image](https://github.com/user-attachments/assets/af8820ad-4d84-4b52-9e94-64b999d03aa6)
(If you would have project called `test`, this configuration `{project[name]_integration}` should work as there is only single `test_integration` channel which ynput Slack bot could reach.
3. try to also modify `Additional message` in Publisher UI
4. publish and check Slack
