### PR TITLE
Settings: Use 'SettingsField' in settings models

### DIFF
--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -1,15 +1,14 @@
-from pydantic import Field
-from ayon_server.settings.common import BaseSettingsModel
+from ayon_server.settings.common import SettingsField, BaseSettingsModel
 
 from .publish_plugins import SlackPublishPlugins
 
 
 class SlackSettings(BaseSettingsModel):
     """Slack project settings."""
-    enabled: bool = Field(default=True)
-    token: str = Field("", title="Auth Token")
+    enabled: bool = SettingsField(default=True)
+    token: str = SettingsField("", title="Auth Token")
 
-    publish: SlackPublishPlugins = Field(
+    publish: SlackPublishPlugins = SettingsField(
         title="Publish plugins",
         description="Fill combination of families, task names and hosts "
                     "when to send notification",

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -1,36 +1,60 @@
-from pydantic import Field
-
-from ayon_server.settings import BaseSettingsModel, task_types_enum
+from ayon_server.settings import (
+    SettingsField,
+    BaseSettingsModel,
+    task_types_enum,
+)
 
 
 class ChannelMessage(BaseSettingsModel):
-    channels: list[str] = Field(default_factory=list, title="Channels")
-    upload_thumbnail: bool = Field(default=True, title="Upload thumbnail")
-    upload_review: bool = Field(default=True, title="Upload review")
-    message: str = Field('',
+    channels: list[str] = SettingsField(
+        default_factory=list,
+        title="Channels"
+    )
+    upload_thumbnail: bool = SettingsField(
+        default=True,
+        title="Upload thumbnail"
+    )
+    upload_review: bool = SettingsField(
+        default=True,
+        title="Upload review"
+    )
+    message: str = SettingsField(
+        "",
         title="Message",
         widget="textarea"
     )
 
 
 class Profile(BaseSettingsModel):
-    product_types: list[str] = Field(default_factory=list, title="Product types")
-    hosts: list[str] = Field(default_factory=list, title="Hosts")
-    task_types: list[str] = Field(
+    product_types: list[str] = SettingsField(
+        default_factory=list,
+        title="Product types"
+    )
+    hosts: list[str] = SettingsField(
+        default_factory=list,
+        title="Hosts"
+    )
+    task_types: list[str] = SettingsField(
         default_factory=list,
         title="Task types",
         enum_resolver=task_types_enum
     )
-    task_names: list[str] = Field(default_factory=list, title="Task names")
-    product_names: list[str] = Field(default_factory=list, title="Product names")
-    review_upload_limit: float = Field(
+    task_names: list[str] = SettingsField(
+        default_factory=list,
+        title="Task names"
+    )
+    product_names: list[str] = SettingsField(
+    default_factory=list,
+    title="Product names"
+    )
+    review_upload_limit: float = SettingsField(
         50.0,
         title="Upload review maximum file size (MB)")
 
     _desc = ("Message sent to channel selected by profile. "
              "Message template can contain {} placeholders from anatomyData "
              "or {review_filepath} for too large review files to link only.")
-    channel_messages: list[ChannelMessage] = Field(
+    channel_messages: list[ChannelMessage] = SettingsField(
         default_factory=list,
         title="Messages to channels",
         description=_desc,
@@ -41,16 +65,16 @@ class Profile(BaseSettingsModel):
 class CollectSlackFamiliesPlugin(BaseSettingsModel):
     _isGroup = True
     enabled: bool = True
-    optional: bool = Field(False, title="Optional")
+    optional: bool = SettingsField(False, title="Optional")
 
-    profiles: list[Profile] = Field(
+    profiles: list[Profile] = SettingsField(
         title="Profiles",
         default_factory=Profile
     )
 
 
 class SlackPublishPlugins(BaseSettingsModel):
-    CollectSlackFamilies: CollectSlackFamiliesPlugin = Field(
+    CollectSlackFamilies: CollectSlackFamiliesPlugin = SettingsField(
         title="Notification to Slack",
         default_factory=CollectSlackFamiliesPlugin,
     )


### PR DESCRIPTION
## Changelog Description
Use `SettingsField` instead of `Field` in settings models.

## Additional review information
We should be using `SettingsField` for a long time, I wonder how it did not fail yet.
