### PR TITLE
Chore: Stricter ruff

### DIFF
--- a/client/ayon_slack/plugins/publish/integrate_slack_api.py
+++ b/client/ayon_slack/plugins/publish/integrate_slack_api.py
@@ -60,7 +60,9 @@ class SlackOperations:
         except SlackApiError as e:
             # # You will get a SlackApiError if "ok" is False
             if e.response.get("error"):
-                error_str = self._enrich_error(str(e.response["error"]), channel)
+                error_str = self._enrich_error(
+                    str(e.response["error"]), channel
+                )
             else:
                 error_str = self._enrich_error(str(e), channel)
             self.log.warning("Error happened: {}".format(error_str),
@@ -348,7 +350,9 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
         not_matched = set(placeholder_keys) - set(fill_keys)
 
         for not_matched_item in not_matched:
-            message = message.replace("{}".format(not_matched_item),
-                                      "{{{}}}".format(not_matched_item))
+            message = message.replace(
+                f"{not_matched_item}",
+                f"{{{not_matched_item}}}"
+            )
 
         return message

--- a/ruff.toml
+++ b/ruff.toml
@@ -37,7 +37,7 @@ indent-width = 4
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
-select = ["E4", "E7", "E9", "F", "W"]
+select = ["E", "F", "W"]
 ignore = []
 
 # Allow fix for all enabled rules (when `--fix`) is provided.

--- a/ruff.toml
+++ b/ruff.toml
@@ -26,7 +26,6 @@ exclude = [
     "node_modules",
     "site-packages",
     "venv",
-    "client/ayon_slack/python2_vendor/",
 ]
 
 # Same as Black.


### PR DESCRIPTION
## Changelog Description
Make ruff more strict. And remove python 2 vendor from ruff ignore paths.

## Testing notes:
1. Check chages.

Requires https://github.com/ynput/ayon-slack/pull/31