### PR TITLE
Implemented optionality with <>

### DIFF
--- a/client/ayon_slack/plugins/publish/integrate_slack_api.py
+++ b/client/ayon_slack/plugins/publish/integrate_slack_api.py
@@ -374,8 +374,8 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
         def replacer(match):
             content = match.group(1)
             # If content contains { or }, remove entire <> substring
-            if '{' in content or '}' in content:
-                return ''
+            if "{" in content or "}" in content:
+                return ""
             # Otherwise, keep it as is (including angle brackets)
             return content
 

--- a/client/ayon_slack/plugins/publish/integrate_slack_api.py
+++ b/client/ayon_slack/plugins/publish/integrate_slack_api.py
@@ -249,6 +249,7 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
             self.log.warning(
                 "Some keys are missing in {}".format(message),
                 exc_info=True)
+        message = self._handle_optionality(message)
 
         return message
 
@@ -356,3 +357,28 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
             )
 
         return message
+
+    def _handle_optionality(self, message: str) -> str:
+        """
+        Removes substrings wrapped in <> if they contain any {} inside.
+
+        '<>' denotes optionality in Anatomy Templates. This allows to write
+        <You uploaded {review_filepath}> which will be completely omitted if
+        no `review_filepath` will be calculated, eg {review_filepath} will stay
+        as a placeholder.
+        """
+
+        # Pattern to find substrings wrapped in <>
+        pattern = r'<([^<>]*)>'
+
+        def replacer(match):
+            content = match.group(1)
+            # If content contains { or }, remove entire <> substring
+            if '{' in content or '}' in content:
+                return ''
+            # Otherwise, keep it as is (including angle brackets)
+            return content
+
+        # Substitute using the replacer function
+        result = re.sub(pattern, replacer, message)
+        return result

--- a/client/ayon_slack/plugins/publish/integrate_slack_api.py
+++ b/client/ayon_slack/plugins/publish/integrate_slack_api.py
@@ -355,28 +355,3 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
             )
 
         return message
-
-    def _handle_optionality(self, message: str) -> str:
-        """
-        Removes substrings wrapped in <> if they contain any {} inside.
-
-        '<>' denotes optionality in Anatomy Templates. This allows to write
-        <You uploaded {review_filepath}> which will be completely omitted if
-        no `review_filepath` will be calculated, eg {review_filepath} will stay
-        as a placeholder.
-        """
-
-        # Pattern to find substrings wrapped in <>
-        pattern = r'<([^<>]*)>'
-
-        def replacer(match):
-            content = match.group(1)
-            # If content contains { or }, remove entire <> substring
-            if "{" in content or "}" in content:
-                return ""
-            # Otherwise, keep it as is (including angle brackets)
-            return content
-
-        # Substitute using the replacer function
-        result = re.sub(pattern, replacer, message)
-        return result


### PR DESCRIPTION
## Changelog Description
Remove content contained in <> if it contains any {}, eg missing keys.

'<>' denotes optionality in Anatomy Templates. This allows to write `<You uploaded {review_filepath}>` which will be completely omitted if no value exists for `review_filepath` key., eg {review_filepath} would stay as a placeholder.

Now also resolves messages like `{root[work]}\{project[name]}\{hierarchy}\{folder[name]}\publish\workfile\{product[name]}\v{version:0>3}`.

## Additional review information
Previously `root[work]` wasn't resolved and version was without padding

! Currently we dont have active Slack token, please hold on user testing until it gets resolved. !

## Testing notes:
1. experiment with `ayon+settings://slack/publish/CollectSlackFamilies/profiles/0/channel_messages/0`
2. example
![image](https://github.com/user-attachments/assets/8e5b78a3-33b7-4fa6-b771-fda48189aeb0)
