### PR TITLE
Resolve root placeholders and version with paddings

### DIFF
--- a/client/ayon_slack/plugins/publish/integrate_slack_api.py
+++ b/client/ayon_slack/plugins/publish/integrate_slack_api.py
@@ -216,9 +216,8 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
         """
 
         fill_data = copy.deepcopy(instance.data["anatomyData"])
-        # Make sure version is string
-        # TODO remove when fixed in ayon-core 'prepare_template_data' function
-        fill_data["version"] = str(fill_data["version"])
+        anatomy = instance.context.data["anatomy"]
+        fill_data["root"] = anatomy.roots
         if review_path:
             fill_data["review_filepath"] = review_path
 

--- a/client/ayon_slack/plugins/publish/integrate_slack_api.py
+++ b/client/ayon_slack/plugins/publish/integrate_slack_api.py
@@ -221,6 +221,11 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
         if review_path:
             fill_data["review_filepath"] = review_path
 
+        version_placeholders = self._find_version_placeholders(
+            message, fill_data["version"])
+        if version_placeholders:
+            fill_data.update(version_placeholders)
+
         message = (
             message
             .replace("{task}", "{task[name]}")
@@ -355,3 +360,23 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
             )
 
         return message
+
+    def _find_version_placeholders(
+        self,
+        message: str,
+        version: int
+    ) -> dict[str,str]:
+        """
+        Finds all {version:X>Y} placeholders in text and returns a dictionary
+        mapping placeholder -> formatted version string.
+        """
+        pattern = r'\{(version:(.?)>(\d+))\}'
+
+        placeholders = {}
+
+        for full_match, pad_char, width_str in re.findall(pattern, message):
+            width = int(width_str)
+            formatted_version = f"{version:{pad_char}>{width}}"
+            placeholders[full_match] = formatted_version
+
+        return placeholders


### PR DESCRIPTION
## Changelog Description
Now it resolves messages like `{root[work]}\{project[name]}\{hierarchy}\{folder[name]}\publish\workfile\{product[name]}\v{version:0>3}`.

## Additional review information
Previously `root[work]` wasn't resolved and version was without padding

! Currently we dont have active Slack token, please hold on user testing until it gets resolved. !

## Testing notes:
1. add `{root[work]}\{project[name]}\{hierarchy}\{folder[name]}\publish\workfile\{product[name]}\v{version:0>3}` or similar to message content
2. check if it resolves correctly on Slack
