### PR TITLE
Chore: Use product base types

### DIFF
--- a/client/ayon_slack/plugins/publish/collect_slack_family.py
+++ b/client/ayon_slack/plugins/publish/collect_slack_family.py
@@ -33,32 +33,26 @@ class CollectSlackFamilies(pyblish.api.InstancePlugin,
         ]
 
     def process(self, instance):
-        task_data = instance.data["anatomyData"].get("task", {})
+        task_name = task_type = None
+        task_entity = instance.data.get("taskEntity")
+        if task_entity:
+            task_name = task_entity["name"]
+            task_type = task_entity["taskType"]
         product_type = instance.data["productType"]
+        product_base_type = instance.data.get("productBaseType")
+        if not product_base_type:
+            product_base_type = product_type
         key_values = {
-            "product_types": product_type,
-            "task_names": task_data.get("name"),
-            "task_types": task_data.get("type"),
-            "hosts": instance.context.data["hostName"],
+            "task_names": task_name,
+            "task_types": task_type,
+            "host_names": instance.context.data["hostName"],
+            "product_base_types": product_base_type,
             "product_names": instance.data["productName"],
-
-            # Backwards compatibility
-            "families": product_type,
-            "tasks": task_data.get("name"),
-            "subsets": instance.data["productName"],
-            "subset_names": instance.data["productName"],
         }
-        # Filter 'key_values' for backwards compatibility
-        if self.profiles:
-            profile_keys = set(self.profiles[0].keys())
-            key_values = {
-                key: value
-                for key, value in key_values.items()
-                if key in profile_keys
-            }
-        profile = filter_profiles(self.profiles, key_values,
-                                  logger=self.log)
 
+        profile = filter_profiles(
+            self.profiles, key_values, logger=self.log
+        )
         if not profile:
             self.log.info("No profile found, notification won't be send")
             return

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from ayon_server.addons import BaseServerAddon
 
-from .settings.main import SlackSettings, DEFAULT_SLACK_SETTING
+from .settings import (
+    SlackSettings,
+    DEFAULT_SLACK_SETTING,
+    convert_settings_overrides,
+)
 
 
 class Slack(BaseServerAddon):
@@ -12,3 +16,13 @@ class Slack(BaseServerAddon):
     async def get_default_settings(self):
         settings_model_cls = self.get_settings_model()
         return settings_model_cls(**DEFAULT_SLACK_SETTING)
+
+    async def convert_settings_overrides(
+        self,
+        source_version: str,
+        overrides: dict[str, Any],
+    ) -> dict[str, Any]:
+        await convert_settings_overrides(source_version, overrides)
+        return await super().convert_settings_overrides(
+            source_version, overrides
+        )

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from ayon_server.addons import BaseServerAddon
 
 from .settings import (

--- a/server/settings/__init__.py
+++ b/server/settings/__init__.py
@@ -1,0 +1,13 @@
+from .main import (
+    SlackSettings,
+    DEFAULT_SLACK_SETTING,
+)
+from .conversions import convert_settings_overrides
+
+
+__all__ = (
+    "SlackSettings",
+    "DEFAULT_SLACK_SETTING",
+
+    "convert_settings_overrides",
+)

--- a/server/settings/conversions.py
+++ b/server/settings/conversions.py
@@ -1,0 +1,27 @@
+from typing import Any
+
+
+def _convert_product_base_types(overrides: dict[str, Any]):
+    profiles = (
+        overrides
+        .get("publish", {})
+        .get("CollectSlackFamilies", {})
+        .get("profiles")
+    )
+    if not profiles:
+        return
+
+    for profile in profiles:
+        if "hosts" in profile:
+            profile["host_names"] = profile.pop("hosts")
+
+        if "product_base_types" not in profile and "product_types" in profile:
+            profile["product_base_types"] = profile.pop("product_types")
+
+
+async def convert_settings_overrides(
+    source_version: str,
+    overrides: dict[str, Any],
+) -> dict[str, Any]:
+    _convert_product_base_types(overrides)
+    return overrides

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -25,14 +25,10 @@ class ChannelMessage(BaseSettingsModel):
     )
 
 
-class Profile(BaseSettingsModel):
-    product_types: list[str] = SettingsField(
+class CollectSlackFamilyProfile(BaseSettingsModel):
+    host_names: list[str] = SettingsField(
         default_factory=list,
-        title="Product types"
-    )
-    hosts: list[str] = SettingsField(
-        default_factory=list,
-        title="Hosts"
+        title="Host names"
     )
     task_types: list[str] = SettingsField(
         default_factory=list,
@@ -43,9 +39,13 @@ class Profile(BaseSettingsModel):
         default_factory=list,
         title="Task names"
     )
+    product_base_types: list[str] = SettingsField(
+        default_factory=list,
+        title="Product base types"
+    )
     product_names: list[str] = SettingsField(
-    default_factory=list,
-    title="Product names"
+        default_factory=list,
+        title="Product names"
     )
     review_upload_limit: float = SettingsField(
         50.0,
@@ -67,9 +67,9 @@ class CollectSlackFamiliesPlugin(BaseSettingsModel):
     enabled: bool = True
     optional: bool = SettingsField(False, title="Optional")
 
-    profiles: list[Profile] = SettingsField(
+    profiles: list[CollectSlackFamilyProfile] = SettingsField(
         title="Profiles",
-        default_factory=Profile
+        default_factory=CollectSlackFamilyProfile
     )
 
 


### PR DESCRIPTION
## Changelog Description
Start use product base types instead of product types.

## Additional review information
Collect slack family is now based on product base type instead of product type.

## Testing notes:
1. Conversion of settings works (you have to have overrides of Collect Slack family in source version).
2. Integration works too based on product base types.
