### PR TITLE
updates fill_data with users publish comment

### DIFF
--- a/client/ayon_slack/plugins/publish/integrate_slack_api.py
+++ b/client/ayon_slack/plugins/publish/integrate_slack_api.py
@@ -218,7 +218,7 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
         """
 
         fill_data = copy.deepcopy(instance.data["anatomyData"])
-        fill_data.update({"comment": instance.data["comment"]})
+        fill_data["comment"] = instance.data["comment"]
         anatomy = instance.context.data["anatomy"]
         fill_data["root"] = anatomy.roots
         if review_path:

--- a/client/ayon_slack/plugins/publish/integrate_slack_api.py
+++ b/client/ayon_slack/plugins/publish/integrate_slack_api.py
@@ -218,6 +218,7 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
         """
 
         fill_data = copy.deepcopy(instance.data["anatomyData"])
+        fill_data.update({"comment": instance.data["comment"]})
         anatomy = instance.context.data["anatomy"]
         fill_data["root"] = anatomy.roots
         if review_path:


### PR DESCRIPTION
refs https://github.com/ynput/ayon-slack/issues/44

## Changelog Description
Adds `comment` to `fill_data` in order to be used in the slack message template.

## Testing notes:
1. build/upload addon
2. use `{comment}` in `ayon+settings://slack/publish/CollectSlackFamilies/profiles/0/channel_messages/0/message`
3. publish something making sure to enter a publish message