### PR TITLE
feat: add User DM option in channel message

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,17 @@ Addon allowing sending notification to Slack channel(s) at the end of publishing
 
 It allows to upload thumbnail and review(for example mp4/mov) to the channel.
 Uploading is limited by configurable file size to spare Slack disk limit.
+
+Direct message to the publishing user:
+-------------------------------------
+Each message in a profile can also DM the AYON user who triggered the publish
+(toggle `Send Slack DM to publishing AYON user`). The AYON user is reconciled to their
+Slack account via a user attribute `slackId`; if it is empty the user's `email`
+attribute is looked up against the Slack API instead.
+
+Setup:
+- Create a user-scoped string attribute named `slackId` in AYON
+  (Settings > Attributes, scope = User) and set it per user to their Slack
+  member id (e.g. `U0XXXXXXX`), or rely on the email fallback.
+- The Slack bot token needs the `users:read.email` (email fallback) and
+  `im:write` (DM delivery) scopes in addition to the existing ones.

--- a/client/ayon_slack/manifest.yml
+++ b/client/ayon_slack/manifest.yml
@@ -19,6 +19,8 @@ oauth_config:
       - chat:write.public
       - files:write
       - channels:read
+      - users:read.email
+      - im:write
 settings:
   org_deploy_enabled: false
   socket_mode_enabled: false

--- a/client/ayon_slack/manifest.yml
+++ b/client/ayon_slack/manifest.yml
@@ -19,6 +19,7 @@ oauth_config:
       - chat:write.public
       - files:write
       - channels:read
+      - users:read
       - users:read.email
       - im:write
 settings:

--- a/client/ayon_slack/plugins/publish/collect_slack_family.py
+++ b/client/ayon_slack/plugins/publish/collect_slack_family.py
@@ -2,6 +2,7 @@ import pyblish.api
 
 from ayon_core.lib.profiles_filtering import filter_profiles
 from ayon_core.lib import attribute_definitions
+from ayon_core.lib.local_settings import get_ayon_user_entity
 from ayon_core.pipeline import AYONPyblishPluginMixin
 
 
@@ -65,6 +66,13 @@ class CollectSlackFamilies(pyblish.api.InstancePlugin,
             prof["review_upload_limit"] = profile.get("review_upload_limit",
                                                       50)
         instance.data["slack_channel_message_profiles"] = selected_profiles
+
+        if any(p.get("send_to_current_user") for p in selected_profiles):
+            attrib = get_ayon_user_entity().get("attrib", {})
+            instance.data["slack_current_user"] = {
+                "slackId": attrib.get("slackId"),
+                "email": attrib.get("email"),
+            }
 
         slack_token = (instance.context.data["project_settings"]
                                             ["slack"]

--- a/client/ayon_slack/plugins/publish/integrate_slack_api.py
+++ b/client/ayon_slack/plugins/publish/integrate_slack_api.py
@@ -48,6 +48,17 @@ class SlackOperations:
 
         return users, groups
 
+    def get_user_id_by_email(self, email):
+        from slack_sdk.errors import SlackApiError
+        try:
+            response = self.client.users_lookupByEmail(email=email)
+            return response["user"]["id"]
+        except SlackApiError:
+            self.log.warning(
+                "Cannot find Slack user for email '{}'".format(email),
+                exc_info=True)
+            return None
+
     def send_message(self, channel, message, publish_files):
         from slack_sdk.errors import SlackApiError
         try:
@@ -176,11 +187,16 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
                 message, publish_files = self._handle_review_upload(
                     message, message_profile, publish_files, review_path)
 
-            for channel in message_profile["channels"]:
+            client = SlackOperations(token, self.log)
+            channels = list(message_profile["channels"])
+            if message_profile.get("send_to_current_user"):
+                dm_channel = self._get_current_user_channel(instance, client)
+                if dm_channel:
+                    channels.append(dm_channel)
+
+            for channel in channels:
                 channel = self._get_filled_content(
                     channel, instance, review_path)
-
-                client = SlackOperations(token, self.log)
 
                 if "@" in message:
                     cache_key = "__cache_slack_ids"
@@ -196,6 +212,18 @@ class IntegrateSlackAPI(pyblish.api.InstancePlugin):
                     message = self._translate_users(message, users, groups)
 
                 client.send_message(channel, message, publish_files)
+
+    def _get_current_user_channel(self, instance, client):
+        """Resolve the publishing user's Slack DM channel (their user id)."""
+        user = instance.data.get("slack_current_user") or {}
+        slack_id = user.get("slackId", None)
+        if slack_id:
+            return slack_id
+        email = user.get("email", None)
+        if email:
+            return client.get_user_id_by_email(email)
+        self.log.warning("No slackId or email for current user; skipping DM")
+        return None
 
     def _handle_review_upload(self, message, message_profile, publish_files,
                               review_path):

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -12,7 +12,11 @@ class ChannelMessage(BaseSettingsModel):
     )
     send_to_current_user: bool = SettingsField(
         default=False,
-        title="Send Slack DM to publishing AYON user"
+        title="Send Slack DM to publishing user",
+        description=(
+            "Uses a custom attribute called `slackId` to match ayon users"
+            "to Slack user accounts. Uses their email as a fallback"
+        )
     )
     upload_thumbnail: bool = SettingsField(
         default=True,

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -10,6 +10,10 @@ class ChannelMessage(BaseSettingsModel):
         default_factory=list,
         title="Channels"
     )
+    send_to_current_user: bool = SettingsField(
+        default=False,
+        title="Send Slack DM to publishing AYON user"
+    )
     upload_thumbnail: bool = SettingsField(
         default=True,
         title="Upload thumbnail"


### PR DESCRIPTION
## Changelog Description
Add support for sending Direct Messages in Slack to users upon their own publish completion. Provides a user with a personal feed of reviewables and publish data, easing the complexity of sharing information within Slack.

## Additional review information

- Uses a custom user attribute `slackId` for cached Slack ID handling, or fallback method of email lookup via Slack API.
- Adds a boolean setting in the existing ayon-slack channel settings, which feeds into existing channel assignment system.
- Can be run independent of any public/private channel profile by not entering a channel name
- Injects the slackId into the existing channel send `for loop`, lightweight and minimal change to existing codebase.


## Testing notes:
1. Updated existing Slack application with updated scopes found in manifest.yml
2. Tested with setting as `true` in existing profile, successfully sent to both Slack Channel and user DM
3. Tested with setting as `true` in new profile with no Slack channel name set, successfully sends as user DM only.
4. user email lookup as fallback is working as intended

<img width="513" height="755" alt="Screenshot 2026-06-11 at 11 43 59" src="https://github.com/user-attachments/assets/cfe4499e-fc38-4924-869e-a051d471ba40" />

